### PR TITLE
Use $_SERVER instead of apache_request_headers()

### DIFF
--- a/templates/api/Router.php
+++ b/templates/api/Router.php
@@ -81,7 +81,7 @@ class Router
     {
       // convert all headers to lowercase:
       $headers = array();
-      foreach(apache_request_headers() as $key => $value) {
+      foreach($_SERVER as $key => $value) {
         $headers[strtolower($key)] = $value;
       }
 


### PR DESCRIPTION
`apache_request_headers()` does not work with nginx-based servers